### PR TITLE
fix Cannot read property 'string' of undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+
+.idea/misc.xml
+.idea/modules.xml
+.idea/react-native-emoji-panel.iml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import {
   Dimensions,
   Image,
@@ -8,6 +8,8 @@ import {
   TouchableOpacity,
   View
 } from 'react-native';
+
+import PropTypes from 'prop-types';
 import Emoji from './lib/emoji';
 
 const WINDOW_WIDTH = Dimensions.get('window').width;


### PR DESCRIPTION
Fix was used in react native 0.49.5  Cannot read property 'string' of undefined